### PR TITLE
Markdown: Darkmode fix

### DIFF
--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -39,7 +39,7 @@ const { frontmatter } = Astro.props;
       >
         <img src="/back.svg" class="h-full" alt="back" />
       </a>
-      <div class="prose mx-auto pt-10 dark:text-white">
+      <div class="prose mx-auto pt-10 dark:prose-invert">
         <slot />
       </div>
     </div>

--- a/src/layouts/Project.astro
+++ b/src/layouts/Project.astro
@@ -39,7 +39,7 @@ import SpeedInsights from "@vercel/speed-insights/astro";
       >
         <img src="/back.svg" class="h-full" alt="back" />
       </a>
-      <div class="prose mx-auto pt-10 dark:text-white">
+      <div class="prose mx-auto pt-10 dark:prose-invert">
         <slot />
       </div>
     </div>


### PR DESCRIPTION
# Problem
The markdown parser was rendering the <a> elements with a darker shade than the regular text.
An additional problem encountered is that the text was hard to read, the contrast was not comfortable.

# Fix
As mentioned in the [official documentation](https://tailwindcss.com/docs/typography-plugin),

`<elem className="prose dark:prose-invert" />`

is the correct way to adapt the rendering to dark mode.